### PR TITLE
explicitly set distance method

### DIFF
--- a/R/get_distance.R
+++ b/R/get_distance.R
@@ -9,5 +9,5 @@
 #' @return An average distance between points
 get_distance = function(p, x){
   new_r = terra::as.points(terra::rast(x, vals = p, nlyr = 1))
-  mean(as.vector(terra::distance(new_r)))
+  mean(as.vector(terra::distance(new_r, method="geo")))
 }


### PR DESCRIPTION
I am harmonizing the default distance lon/lat method in terra to haversine; but that results in a revdep error with bespatial. 
This change -- explicitly setting the distance method in bespatial -- fixes that. 